### PR TITLE
No hashed password in case of several errors

### DIFF
--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -31,7 +31,7 @@ defmodule PhoenixTokenAuth.Registrator do
     |> set_hashed_password
   end
 
-  def set_hashed_password(changeset = %{errors: [_]}), do: changeset
+  def set_hashed_password(changeset = %{errors: [_ | _]}), do: changeset
   def set_hashed_password(changeset = %{params: %{"password" => password}}) when password != "" and password != nil do
     hashed_password = Util.crypto_provider.hashpwsalt(password)
 


### PR DESCRIPTION
When several errors occured, def set_hashed_password(changeset = %{errors: [_]) did not match. Then, it was matching the last definition, returning the hashed password
